### PR TITLE
[#5] Enable Danger

### DIFF
--- a/.github/workflows/review_pull_request.yml
+++ b/.github/workflows/review_pull_request.yml
@@ -68,7 +68,7 @@ jobs:
           ruby-version: '2.7'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
-#      - name: Run Danger
-#        env:
-#          DANGER_GITHUB_API_TOKEN: ${{ secrets.GH_TOKEN }}
-#        run: bundle exec danger
+      - name: Run Danger
+        env:
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: bundle exec danger


### PR DESCRIPTION
Close https://github.com/thiennguyen0196/estate-listing/issues/5

## What happened 👀

- Re-enable Danger because the GH_TOKEN has been fixed

## Proof Of Work 📹

The CI is passed with danger on
